### PR TITLE
Stylistic changes and display output in a box

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -11,8 +11,13 @@
   }
   form {
     position: fixed;
-    top: 0;
+    top: 7em;
     left: 0;
+  }
+  h1 {
+    text-align: center;
+    padding: 0;
+    font-size: 3em;
   }
   #palettes, fieldset, #legend {
     padding: 1em;
@@ -21,7 +26,7 @@
     background: #FFF;
   }
   #palettes {
-   margin-top: 10em;
+   margin-top: 11em;
   }
   table, tbody, tr, td, th {
     border: 0 none #FFF;
@@ -38,12 +43,25 @@
     padding: 1em;
     border: 1px solid #666;
     height: 1em;
-    width: 10em;
+    width: 11em;
     text-align: center;
     background: #FFF;
+    position: fixed;
+    left: 69%;
+    top: 65%;
+    z-index: 0;
+  }
+  #outputdisplay {
+     height: 11em; 
+     width: 11em;
+     border: 2px solid black;
+     position: fixed; 
+     left: 70%;
+     top: 45%;
   }
 </style>
 <body>
+  <h1>Palette.js</h1>
   <form>
     <fieldset>
       <legend>Settings</legend>
@@ -58,6 +76,7 @@
 
     </fieldset>
   </form>
+  <div id="outputdisplay"></div>
   <div id=palettes title="Hover color to see it's value, click to keep selection."></div>
   <div id=tooltip></div>
   <div id=legend>

--- a/demo.js
+++ b/demo.js
@@ -120,6 +120,7 @@
 
 
   var palettes = byId('palettes');
+  var outputdisplay = byId('outputdisplay')
   var defaultBackground = palettes.style.backgroundColor;
   var tooltip = byId('tooltip');
 
@@ -134,7 +135,7 @@
     bg = bg || defaultBackground;
     tooltip.appendChild(document.createTextNode(bg));
     tooltip.style.display = bg ? '' : 'none';
-    palettes.style.backgroundColor = bg;
+    outputdisplay.style.backgroundColor = bg;
   };
   palettes.addEventListener('mousemove', mouseMoveHandler, false);
   palettes.addEventListener('mouseover', mouseMoveHandler, false);


### PR DESCRIPTION
- Use a small output box to display the color, which is less distracting
- Add a title to the page
- Place the tooltip under the output box