### PR TITLE
Add plumbing required for npm distribution

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "google-palette",
+  "version": "1.0.0",
+  "description": "Script for generating colour palettes for use with graphs, charts and cartography.",
+  "main": "palette.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/google/palette.js.git"
+  },
+  "keywords": [
+    "palette",
+    "palette.js",
+    "palettejs",
+    "google",
+    "google-color-palette"
+  ],
+  "author": "Google Inc.",
+  "license": "Apache-2.0",
+  "homepage": "https://github.com/google/palette.js#readme"
+}

--- a/palette.js
+++ b/palette.js
@@ -1472,3 +1472,7 @@ palette.SchemeType;
     palette.register(scheme);
   }
 })();
+
+if(typeof module === "object" && module.exports) {
+  module.exports = palette
+}


### PR DESCRIPTION
Thanks for the library. It's great to find something that people have put so much time and energy into in order to ensure that charts can be meaningful and accessible.

This pr is basically a much lighter version of #5

This should be the minimum required in order to make it releasable via npm.

I've published my fork to npm here:

https://www.npmjs.com/package/google-palette

Since it got me past a block in the project I'm using this in. If you want, though, just let me know which npm user to assign the ownership of the npm package to and I can hand it over.